### PR TITLE
Loosen pint requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 dependencies = [
   "DLite-Python>=0.3.16",
   "pybacktrip @ git+https://github.com/xAlessandroC/PyBackTrip@v1.0.0",
-  "pint~=0.18"
+  "pint>=0.16.1,<1"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This is necessary to support 'aiida-pseudo' requirements. aiida-pseudo is an ExecFlow dependency.

**Note**: I have not tested, nor do I know if pint versions in the range 0.16.1-0.18 will work with the code base of OntoFlow.